### PR TITLE
Fix composer-required plugin semantics

### DIFF
--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -141,11 +141,13 @@ class PluginLifecycleService
             return $installContext;
         }
 
-        // TODO NEXT-1797: Not usable with Composer 1.8, Wait for Release of Composer 2.0
-        if (next1797()) {
-            $this->executor->require($plugin->getComposerName());
-        } else {
-            $this->requirementValidator->validateRequirements($pluginBaseClass, $shopwareContext, 'install');
+        if ($plugin->isManagedByComposer()) {
+            // TODO NEXT-1797: Not usable with Composer 1.8, Wait for Release of Composer 2.0
+            if (next1797()) {
+                $this->executor->require($plugin->getComposerName());
+            } else {
+                $this->requirementValidator->validateRequirements($pluginBaseClass, $shopwareContext, 'install');
+            }
         }
 
         $pluginData['id'] = $plugin->getId();

--- a/src/Core/Framework/Plugin/PluginLifecycleService.php
+++ b/src/Core/Framework/Plugin/PluginLifecycleService.php
@@ -141,13 +141,11 @@ class PluginLifecycleService
             return $installContext;
         }
 
-        if ($plugin->isManagedByComposer()) {
-            // TODO NEXT-1797: Not usable with Composer 1.8, Wait for Release of Composer 2.0
-            if (next1797()) {
-                $this->executor->require($plugin->getComposerName());
-            } else {
-                $this->requirementValidator->validateRequirements($pluginBaseClass, $shopwareContext, 'install');
-            }
+        // TODO NEXT-1797: Not usable with Composer 1.8, Wait for Release of Composer 2.0
+        if (next1797()) {
+            $this->executor->require($plugin->getComposerName());
+        } elseif ($plugin->isManagedByComposer()) {
+            $this->requirementValidator->validateRequirements($pluginBaseClass, $shopwareContext, 'install');
         }
 
         $pluginData['id'] = $plugin->getId();


### PR DESCRIPTION
This PR does two things.

**(1)**

When installing a plugin to the `custom/plugins` directory, Shopware will then try to verify that Shopware's main composer `vendor/` folder contains all dependencies specified in that plugin's `composer.json`. This is problematic since plugins may be distributed as e.g. ZIP files which ship their own `vendor/` directory, which may include additional libraries. In this case, even though the plugin ships its own dependencies, Shopware will refuse to install the plugin.

This PR fixes this issue by only validating composer dependencies for plugins which are `managedByComposer`. This way, Shopware validates plugin dependencies if and only if the plugin is installed into the Shopware installation using composer. 

**(2)**

shopware/development's `composer.json` adds `custom/plugins` as an additonal repository: https://github.com/shopware/development/blob/55cc7cb310d16e0bc614bfcfe108e0686ccbe586/composer.json#L9-L15

This allows shop administrators to `composer require` plugins which reside in `custom/plugins` into Shopware's `vendor/` directory, resolving the plugins' dependencies and generating optimized classmaps in the process. However, if you try this and then run `bin/console plugin:refresh`, this will fail with a unique constraint violation because the `PluginFinder` tries to add the plugin from `custom/plugins` as well as from the `vendor/` directory.

To fix this, this PR resolves these conflicts by always preferring plugins installed into the `vendor/` folder over those installed in `custom/plugins`.