### PR TITLE
Fix upsert of custom search bar types

### DIFF
--- a/src/Administration/Resources/administration/src/app/service/search-type.service.js
+++ b/src/Administration/Resources/administration/src/app/service/search-type.service.js
@@ -55,7 +55,7 @@ export default function createSearchTypeService() {
     }
 
     function upsertType(name, configuration) {
-        $typeStore[name] = { ...$typeStore[name], ...{ configuration } };
+        $typeStore[name] = { ...$typeStore[name], ...configuration };
     }
 
     function getTypes() {


### PR DESCRIPTION
To use the `sw-search-bar` with custom entities, you need to add (upsert) a new search type. When using the respective upsert function of the `SearchTypeService`, the configuration of the custom type is stored in a `configuration` property:

https://github.com/shopware/platform/blob/27558b4c00452ba25c5f99de42da37144b37e723/src/Administration/Resources/administration/src/app/service/search-type.service.js#L57-L59

The upsert call

```
searchTypeService.upsertType(
    'some_custom_entity',
    {
        entityName: 'some_custom_entity',
        ...
    }
 );
```

will result in

```
const $typeStore = {
...
    some_custom_entity: {
        configuration: {
            entityName: 'product',
            ...
        },
    },
...
}
```

Whereas no such `configuration` property is present in the default types here:
https://github.com/shopware/platform/blob/27558b4c00452ba25c5f99de42da37144b37e723/src/Administration/Resources/administration/src/app/service/search-type.service.js#L14-L19

and not used in the `sw-search-bar` here:
https://github.com/shopware/platform/blob/9ad84b26097c066ac9120953517008ccf5233c05/src/Administration/Resources/administration/src/app/component/structure/sw-search-bar/index.js#L88

This is caused by an incorrect usage of the spread operator at https://github.com/shopware/platform/blob/27558b4c00452ba25c5f99de42da37144b37e723/src/Administration/Resources/administration/src/app/service/search-type.service.js#L58, which this PR fixes.